### PR TITLE
531, Show Finto API queries in correct language

### DIFF
--- a/ckanext/kata/helpers.py
+++ b/ckanext/kata/helpers.py
@@ -593,7 +593,15 @@ def get_labels_for_uri_nocache(uri, ontology=None):
     if jsondata.get('graph'):
         for item in jsondata['graph']:
             if item.get('uri') == uri:
-                return item['prefLabel']
+                translations = item['prefLabel']
+
+                # When FINTO has only one translation for a word
+                # it returns a singular dict item. In this case we need
+                # to return it within a list to have a consistent return value
+                if isinstance(translations, dict):
+                    return [translations]
+
+                return translations
     return None
 
 
@@ -606,7 +614,7 @@ def get_label_for_uri(uri, ontology=None, lang=None):
     :param lang: language of the label. If not provided, uses the language of environment
     :return: resolved label by given language or original string if uri can not be resolved
     '''
-    if not uri.startswith("http://www.yso.fi") or not isinstance(uri, basestring):
+    if not isinstance(uri, basestring) or not uri.startswith("http://www.yso.fi"):
         return uri
 
     try:
@@ -642,3 +650,15 @@ def disciplines_string_resolved(disciplines, ontology=None, lang=None):
         return ", ".join([get_label_for_uri(x, ontology, lang) for x in disc_list])
     else:
         return disciplines
+
+def format_facet_labels(facet_item):
+    '''
+    This function is used by facet_list.html to format the labels properly.
+    In the case of Etsin, the facet label url's are resolved and returned
+    according to the display language
+
+    :param facet_item: a dict containing the Finto uri as display_name
+    :return: a resolved label in an according language
+    '''
+
+    return get_label_for_uri(facet_item['display_name'])

--- a/ckanext/kata/theme/templates/package/read.rdf
+++ b/ckanext/kata/theme/templates/package/read.rdf
@@ -138,6 +138,11 @@
       <nrd:discipline py:if="h.is_url(disc)==False and disc">${ disc }</nrd:discipline>
     </py:for>
 
+    <py:for each="tag in c.pkg_dict.get('tags', '')">
+      <nrd:keyword py:if="h.is_url(tag.get('display_name', ''))" rdf:resource="${ tag.get('display_name', '') }"/>
+      <nrd:keyword py:if="h.is_url(tag.get('display_name', ''))==False and tag">${ tag.get('display_name', '') }</nrd:keyword>
+    </py:for>
+
     <py:for each="rel in h.get_related_urls(c.pkg)">
       <dct:isReferencedBy rdf:resource="${ rel }"/>
     </py:for>

--- a/ckanext/kata/theme/templates/package/snippets/metadata_info.html
+++ b/ckanext/kata/theme/templates/package/snippets/metadata_info.html
@@ -118,8 +118,12 @@
   {% endif%}
 </section>
 {% block package_tags %}
-  {% if pkg_dict.tags %}<h3 class="module-content">{{ _('Keywords') }}</h3>{% endif %}
+  {% if pkg_dict.tags %}
+    <section class="module-content">
+    <h3>{{ _('Keywords') }}</h3>
+  {% endif %}
   {% snippet "package/snippets/tags.html", tags=pkg_dict.tags %}
+  </section>
 {% endblock %}
 <section class="module-content additional-info">
 <h3>{{ _('Usage information') }}</h3>

--- a/ckanext/kata/theme/templates/package/snippets/package_basic_information.html
+++ b/ckanext/kata/theme/templates/package/snippets/package_basic_information.html
@@ -57,9 +57,9 @@
         {{ _('Search keywords from') }} <a href="{{ _('http://finto.fi/koko/en/') }}" target="_blank">KOKO</a>{{ _(' ontology, select keywords with enter or mouse click.') }}
         {{ kata_form.tooltip(tooltip=_("Field is compulsory.<br /><br />Add keywords that describe your data. Once you start typing, you will automatically get suggestions for matching keywords. You can then select the appropriate suggestion with a mouse click, or you can enter your own keywords. If you make a mistake, you can remove a keyword by clicking the \'x\' next to it.<br /><br />The suggestions are retrieved from the Finto vocabulary service (see http://finto.fi/en/). Note that you must have JavaScript enabled in your browser in order for the automatic suggestions to work.")) }}
       </p>
-
-
-      {% set tag_attrs = {'data-module': 'autocomplete', 'data-module-tags': 'true', 'data-module-source': '/api/2/util/tag/autocomplete?incomplete=?'} %}
+      
+      {% set autocomplete_source = '/api/2/util/tag/autocomplete?incomplete=?&language=' ~ h.lang()  %}
+      {% set tag_attrs = {'data-module': 'autocomplete', 'data-module-tags': 'true', 'data-module-source': autocomplete_source, 'data-module-key': 'key', 'data-module-label': 'label'} %}
       {{ form.input('tag_string', id='field-tags', label=_('Keywords'), placeholder=_('eg. economy, mental health, government'), value=data.tag_string, error=errors.tag_string, classes=['control-medium'], control_classes=['error-block-autocomplete'], attrs=tag_attrs) }}
     </div>
     <br />
@@ -75,7 +75,8 @@
         {{ _('Search words from') }} <a href="{{ _('http://finto.fi/okm-tieteenala/en/') }}" target="_blank">{{ _('okm-tieteenala') }}</a> {{ _('ontology, select keywords with enter or mouse click.') }}
         {{ kata_form.tooltip(tooltip=_("Enter the academic discipline or disciplines to which your dataset belongs.<br /><br />Type the name of the discipline in the search box below. Once you start typing, you will automatically get suggestions for matching discipline names. The disciplines you enter must be selected from the given suggestions. You can select the appropropriate discipline from the list of suggestions with a mouse click. If you make a mistake, you can remove a discipline by clicking the \'x\' next to it.<br /><br />The suggestions are retrieved from the Finto vocabulary service (http://finto.fi/en/). Note that you must have JavaScript enabled in your browser in order for the automatic suggestions to work.")) }}
       </p>
-      {% set disc_attrs = {'data-module': 'autocomplete', 'data-module-tags': 'true', 'data-module-source': '/api/2/util/discipline_autocomplete?incomplete=?', 'data-module-key': 'key', 'data-module-label': 'label'} %}
+      {% set autocomplete_source = '/api/2/util/discipline_autocomplete?incomplete=?&language=' ~ h.lang()  %}
+      {% set disc_attrs = {'data-module': 'autocomplete', 'data-module-tags': 'true', 'data-module-source': autocomplete_source , 'data-module-key': 'key', 'data-module-label': 'label'} %}
       {{ form.input('discipline', id='discipline_field', label=_('Disciplines'), placeholder=_('eg. Matematiikka'), value=data.discipline, error=errors.discipline, classes=['control-medium'], control_classes=['error-block-autocomplete'], attrs=disc_attrs) }}
       </div>
     </div>

--- a/ckanext/kata/theme/templates/snippets/facet_list.html
+++ b/ckanext/kata/theme/templates/snippets/facet_list.html
@@ -37,6 +37,9 @@ within_tertiary
   page and not the left column.
 
 #}
+
+{% set label_function = h.format_facet_labels %}
+
 {% with items = items or h.get_facet_items_dict(name) %}
 {% set found = False %}
   {% if within_tertiary %}
@@ -65,9 +68,6 @@ within_tertiary
           {% for item in items %}
             {% set href = h.remove_url_param(name, item.name, extras=extras) if item.active else h.add_url_param(new_params={name: item.name}, extras=extras, alternative_url=alternative_url) %}
             {% set label = label_function(item) if label_function else item.display_name %}
-            {% if title == _('Discipline') %}
-              {% set label = h.get_label_for_uri(label, 'okm-tieteenala') %}
-            {% endif %}
             {% set label_truncated = h.truncate(label, 22) if not label_function else label %}
             {% set count = count_label(item['count']) if count_label else ('(%d)' % item['count']) %}
             <li class="{{ nav_item_class or 'nav-item' }}{% if item.active %} active{% endif %}">

--- a/ckanext/kata/theme/templates/snippets/tag_list.html
+++ b/ckanext/kata/theme/templates/snippets/tag_list.html
@@ -1,0 +1,13 @@
+{#
+render a list of tags linking to the dataset search page
+tags: list of tags
+#}
+{% set _class = _class or 'tag-list' %}
+<ul class="{{ _class }}">
+  {% for tag in tags %}
+    {% set resolved_name = h.get_label_for_uri(tag.display_name) %}
+    <li>
+      <a class="tag" href="{% url_for controller='package', action='search', tags=tag.name %}">{{ h.truncate(resolved_name, 22) }}</a>
+    </li>
+  {% endfor %}
+</ul>


### PR DESCRIPTION
- Both the keyword and discipline search boxes now show the appropriate language suggestions only
- The keywords are now saved as URI's, which are later resolved from the API in appropriate templates
- The Solr index is updated to include the resolved keywords
- Workaround for FINTO returning a single dict instead of list of dicts when there are no translations found
- Add resource entries to RDF export
- Fix Keywords Well layout overflowing into parent div in metadata_info.html